### PR TITLE
Regridding

### DIFF
--- a/environments/linux.yaml
+++ b/environments/linux.yaml
@@ -2,10 +2,17 @@ channels:
   - conda-forge
   - pyviz
 dependencies:
+  - python=3.10
   - pip
+  - matplotlib
+  - cartopy
   - pyinterp
   - xarray
+  - zarr
   - dask
   - netCDF4
   - bottleneck
   - scipy
+  - pyinterp
+  - xesmf
+  - pytest

--- a/oceanbench/_src/geoprocessing/gridding.py
+++ b/oceanbench/_src/geoprocessing/gridding.py
@@ -1,63 +1,120 @@
 import xarray as xr
-import functools as ft
-import pandas as pd
-from collections import defaultdict
-
-def parse_regular_dim(ds, dim, tol):
-    dmin, dmax, dd = ds.pipe(
-        lambda ds: (ds[dim].min().values, ds[dim].max().values, ds[dim].diff(dim).values)
-    )
-    if (dd.min() - dd.max()) > tol:
-        raise Exception(f"Irregular {dim} dimension")
-    return dmin, dmax, dd.min()
+import xesmf as xe
+import numpy as np
+import pyinterp
+import pyinterp.backends.xarray
 
 
-def bin_values(values, resolution, start_from=None):
-    start_from = start_from or 0
-    return (values - start_from) / resolution // 1 * resolution + start_from
+def to_dim(ds, v):
+    """
+    ds: xr.Dataset
+    v: one dimensional variable or coordinates name
+
+    Return: xr.Dataset  with v as a dimension
+    """
+    if v in ds.dims:
+        return ds
+    return ds.swap_dims({ds[v].dims[0]: v})
 
 
-def compute_grid_coords(ds, resolutions, start_froms=None, prefix='grid_'):
-    start_froms = start_froms or defaultdict(lambda :None)
-    return (
-            ds
-            .pipe(
-                lambda ds: ds.assign(**{
-                    f'{prefix}{coord}': bin_values(ds[coord], resolutions[coord], start_froms[coord])
-                    for coord in resolutions.keys()
-            }))
+def grid_da(da, binning):
+    """
+    da: xr.DataArray (with lon and lat coordinates
+    binning: pyinterp.Binning
+
+    Return: tuple (dim_names, binned_da_values)
+    """
+    binning.clear()
+    values = np.ravel(da.values)
+    lons = np.ravel(da.values)
+    lats = np.ravel(da.values)
+    msk = np.isfinite(values)
+    binning.push(lons[msk], lats[msk], values[msk])
+    return (('time', 'lat', 'lon'), binning.variable('mean').T[None, ...])
+
+
+def coord_based_to_grid(coord_based_ds, target_grid_ds, data_vars=None):
+    """
+        coord_based_ds: xr.Dataset with time, lat, lon coordinates
+        target_grid_ds: xr.Dataset with  uniform time, lat, lon coordinates
+        data_vars: Optional[Iterable[str]] variables of coord_based_ds to include in return dataset,
+                      if None, use all the variables (other that time, lat, lon)
+
+        Return: xr.Dataset a dataset with same dimensions and coordinates as target_grid_ds and averaged 
+                      values of coord_based_ds for each data_vars
+    """
+    if data_vars is None:
+        data_vars = set(coord_based_ds.variables) - {'time', 'lat', 'lon'}
+
+    ds = to_dim(coord_based_ds, 'time')
+    t_res = target_grid_ds.time.diff('time').values.mean()
+    binning = pyinterp.Binning2D(pyinterp.Axis(target_grid_ds.lon.values), pyinterp.Axis(target_grid_ds.lat.values))
+
+    grid_dses = []
+    for t in target_grid_ds.time:
+        tds = ds.isel(time=(ds.time > (t - t_res/2)) & (ds.time <= (t + t_res/2)))
+        grid_dses.append(
+           xr.Dataset(
+               {v: grid_da(tds[v], binning) for v in data_vars},
+               {'time': [t.values], 'lat': np.array(binning.y), 'lon': np.array(binning.x)}
+            ).astype('float32', casting='same_kind')
         )
+    tgt_ds = xr.concat(grid_dses, dim='time')
+    return tgt_ds
 
 
-def multi_groupby(ds, groupbys, aggfn=None):
-    if aggfn is None:
-        aggfn = ft.partial(pd.DataFrame.mean, numeric_only=False, skipna=True)
+def grid_to_regular_grid(src_grid_ds, tgt_grid_ds):
+    """
+        src_grid_ds: xr.Dataset with regular lat, lon coordinates (uniform or curvilinear)
+        tgt_grid_ds: xr.Dataset with  uniform lat, lon coordinates
 
-    return  (
-        ds
-        .to_dataframe()
-        .reset_index()
-        .groupby(groupbys)
-        .agg(aggfn)
-        .to_xarray()
+        Return: xr.Dataset a dataset with same lat, lon coordinates as tgt_grid_ds 
+                      and bilinearly interpolated  values of src_grid_ds.
+                    (time coordinates remains unchanged)
+    """
+    reggridder = xe.Regridder(src_grid_ds, tgt_grid_ds, "bilinear", unmapped_to_nan=True)
+    return reggridder(src_grid_ds, keep_attrs=True)
+
+
+def interp_da(da, tgt_coords):
+    """
+    da: xr.DataArray with uniform time, lat, lon coordinates
+    tgt_coords: dict[str: np.array] Mapping from dimension names to the coordinates to interpolate.
+        Coordinates must be array-like.  array of coordinates of the points of interpolation
+
+    Return: np.array The interpolated values.
+
+    Perform bilinear interpolation spatially followed by a linear interpolation temporally
+    """
+    interpolator = pyinterp.backends.xarray.Grid3D(da)
+    return interpolator.trivariate(tgt_coords)
+
+
+def grid_to_coord_based(src_grid_ds, tgt_coord_based_ds, data_vars=None):
+    """
+        src_grid_ds: xr.Dataset with uniform time, lat, lon coordinates
+        tgt_coord_based_ds: xr.Dataset with  time, lat, lon coordinates
+        data_vars: Optional[Iterable[str]] variables of src_grid_ds to include in return dataset,
+                      if None, use all the variables with dimensions (time, lat, lon)
+
+        Return: xr.Dataset a dataset with same time, lat, lon coordinates as tgt_coord_based_ds 
+                      and interpolated  values of src_grid_ds.
+
+        Perform bilinear interpolation spatially followed by a linear interpolation temporally
+    """
+    if data_vars is None:
+        data_vars = [
+            v for v in src_grid_ds.variables
+            if set(src_grid_ds[v].dims) == {'time', 'lat', 'lon'}
+        ]
+
+    ref = tgt_coord_based_ds.lon
+    coords = dict(
+        lon=np.ravel(ref.values),
+        lat=np.ravel(tgt_coord_based_ds.lat.transpose(*ref.dims).values),
+        time=np.ravel(tgt_coord_based_ds.time.transpose(*ref.dims).values),
     )
-
-def coord_based_to_grid(coord_based_ds: xr.Dataset, target_grid_ds: xr.Dataset):
-    tmin, _, dt = parse_regular_dim(target_grid_ds, 'time', pd.to_timedelta('1s'))
-    xmin, _, dx = parse_regular_dim(target_grid_ds, 'lon', 1e-6)
-    ymin, _, dy = parse_regular_dim(target_grid_ds, 'lat', 1e-6)
-
-    resolutions = dict(time=dt, lon=dx, lat=dy)
-    start_froms = dict(time=tmin, lon=xmin, lat=ymin)
-    ds_with_grid_coords = compute_grid_coords(coord_based_ds, resolutions, start_froms)
-
-    gridded = (
-        ds_with_grid_coords
-        .pipe(ft.partial(multi_groupby, groupbys=[f'grid_{coord}' for coord in resolutions.keys()]))
-        .drop_vars(resolutions.keys())
-        .rename(**{f'grid_{coord}': coord for coord in resolutions.keys()})
-        .reindex_like(target_grid_ds)
+    return xr.Dataset(
+        {v: (ref.dims, np.reshape(interp_da(src_grid_ds[v], coords), ref.shape), src_grid_ds[v].attrs) for v in data_vars},
+        tgt_coord_based_ds.coords
     )
-
-    return gridded
-

--- a/oceanbench/_src/geoprocessing/test_gridding.py
+++ b/oceanbench/_src/geoprocessing/test_gridding.py
@@ -4,6 +4,22 @@ import numpy as np
 import pandas as pd
 import oceanbench._src.geoprocessing.gridding as gridding
 
+@pytest.fixture()
+def ssh_attrs():
+    return dict( units='m', long_name='Sea Surface Height',)
+
+@pytest.fixture()
+def time_attrs():
+    return dict(long_name='Date')
+
+
+@pytest.fixture()
+def lon_attrs():
+    return dict(units='degrees_east', long_name='Longitude')
+
+@pytest.fixture()
+def lat_attrs():
+    return dict(units='degrees_north', long_name='Latitude')
 
 @pytest.fixture()
 def test_domain():
@@ -14,7 +30,7 @@ def test_domain():
     )
 
 @pytest.fixture()
-def simple_coord_based_ds_1d(test_domain):
+def simple_coord_based_ds_1d(test_domain, ssh_attrs, time_attrs, lon_attrs, lat_attrs):
     n_points = 100
     day =  np.arange(n_points) // 20
     time =  test_domain['time'][0] + day*pd.to_timedelta('1D') + (np.arange(n_points) % 20) * pd.to_timedelta('1H')
@@ -22,26 +38,37 @@ def simple_coord_based_ds_1d(test_domain):
     lon =  test_domain['lon'][0] + (np.arange(n_points) % 20) * 0.2
     return xr.Dataset(
         {
-            'ssh': ('idx', np.sin(np.linspace(0, 3, 100))),
-            'time': ('idx', time),
-            'lat': ('idx', lat),
-            'lon': ('idx', lon),
+            'ssh': ('idx', np.ones_like(np.linspace(0, 3, 100)), ssh_attrs),
         },
-        {'idx': np.arange(100)}
+        {
+            'idx': np.arange(100),
+            'time': ('idx', time, time_attrs),
+            'lat': ('idx', lat, lat_attrs),
+            'lon': ('idx', lon, lon_attrs),
+        }
+
     ) 
 
-@pytest.fixture()
-def simple_grid_ds_12H_05(test_domain):
-    dt = pd.to_timedelta('12H')
-    dx = 0.5
+def _mk_grid_ds(dt, dx, test_domain, ssh_attrs, time_attrs, lon_attrs, lat_attrs):
     return xr.Dataset(
         coords = {
-            'time': pd.date_range(*test_domain['time'], freq=dt),
-            'lat': np.arange(*test_domain['lat'], dx),
-            'lon': np.arange(*test_domain['lon'], dx),
+            'time': ('time', pd.date_range(*test_domain['time'], freq=dt), time_attrs),
+            'lat': ('lat', np.arange(*test_domain['lat'], dx), lat_attrs),
+            'lon': ('lon', np.arange(*test_domain['lon'], dx), lon_attrs),
         }
-    ) 
+    ).assign(ssh=lambda ds: (ds.dims, np.ones([*ds.dims.values()]), ssh_attrs))
 
+@pytest.fixture()
+def simple_grid_ds_12H_05(test_domain, ssh_attrs, time_attrs, lon_attrs, lat_attrs):
+    dt = pd.to_timedelta('12H')
+    dx = 0.5
+    return _mk_grid_ds(dt, dx, test_domain, ssh_attrs, time_attrs, lon_attrs, lat_attrs)
+
+@pytest.fixture()
+def simple_grid_ds_24H_01(test_domain, ssh_attrs, time_attrs, lon_attrs, lat_attrs):
+    dt = pd.to_timedelta('1D')
+    dx = 0.1
+    return _mk_grid_ds(dt, dx, test_domain, ssh_attrs, time_attrs, lon_attrs, lat_attrs)
 
 def test_coord_based_to_grid(simple_grid_ds_12H_05, simple_coord_based_ds_1d):
     gridded = gridding.coord_based_to_grid(simple_coord_based_ds_1d, simple_grid_ds_12H_05)
@@ -50,12 +77,51 @@ def test_coord_based_to_grid(simple_grid_ds_12H_05, simple_coord_based_ds_1d):
             simple_grid_ds_12H_05[['lat', 'lon']],
     )
     
+    xr.testing.assert_allclose(
+            gridded.time,
+            simple_grid_ds_12H_05.time,
+    )
+    
+    values = gridded.ssh.values
+    msk = np.isfinite(values)
+    assert msk.sum()>0, "should have finite values"
+    np.testing.assert_almost_equal(values[msk], 1.), "Gridding ones should make ones"
 
-def test_parse_regular_dim(simple_grid_ds_12H_05):
-    assert  False
+    
+def test_grid_to_coord_based(simple_grid_ds_12H_05, simple_coord_based_ds_1d):
+    trackified = gridding.grid_to_coord_based(simple_grid_ds_12H_05, simple_coord_based_ds_1d)
+    xr.testing.assert_allclose(
+            trackified[['lat', 'lon']],
+            simple_coord_based_ds_1d[['lat', 'lon']],
+    )
+    xr.testing.assert_allclose(
+            trackified.time,
+            simple_coord_based_ds_1d.time,
+    )
+    
+    values = trackified.ssh.values
+    msk = np.isfinite(values)
+    assert msk.sum()>0, "should have finite values"
+    np.testing.assert_almost_equal(values[msk], 1.), "Gridding ones should make ones"
 
-def test_bin_values(simple_grid_ds_12H_05):
-    assert  False
 
-def test_multi_groupby(simple_grid_ds_12H_05):
-    assert  False
+def test_regular_grid_to_regular_grid(simple_grid_ds_12H_05, simple_grid_ds_24H_01):
+    regridded = gridding.grid_to_regular_grid(simple_grid_ds_12H_05, simple_grid_ds_24H_01)
+    print(regridded)
+    xr.testing.assert_allclose(
+            regridded[['lat', 'lon']],
+            simple_grid_ds_24H_01[['lat', 'lon']],
+    )
+    xr.testing.assert_allclose(
+            regridded.time,
+            simple_grid_ds_12H_05.time,
+    )
+    
+    values = regridded.ssh.values
+    print(np.nanmin(values))
+    print(np.nanmax(values))
+    msk = np.isfinite(values)
+    assert msk.sum()>0, "should have finite values"
+    np.testing.assert_almost_equal(values[msk], 1.), "Gridding ones should make ones"
+
+


### PR DESCRIPTION
https://github.com/jejjohnson/oceanbench/issues/13

Done in this PR:
**Implementation wise:**

- [x] griddify (using pyinterp)
   - tried with pandas but had some floating precision issues during reindexing 
- [x] alongtrackify (using pyinterp)
    - Going with this because it allows for a differentiated processing of the spatial interpolation versus the temporal interpolation as done in the swot simulator  
- [x] regridding (using xesmf)
     - It's really just a wrapper on the Regridder class, but at least we propose a standard usage
  

**test_wise:**
- [x] added toy datasets that used the conventions monday 
- [x] testing interpolation and regridding of constant values

**Not done:**
- [ ] clean notebook

Notes:
/!\ the data we have does not respect the conventions of the project, I think if we want to test our code on real data the next step should be to implement the validation/ formatting steps of the data. this way we could also systematically test that our processing steps do not remove attributes etc...